### PR TITLE
bump sys.version_info check to 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,8 @@ import sys
 DESCRIPTION = "Mongita is a lightweight embedded document database that " \
               "implements a commonly-used subset of the MongoDB/PyMongo interface."
 
-if sys.version_info[:2] < (3, 6):
-    print("ERROR: this package requires Python 3.6 or later!")
+if sys.version_info[:2] < (3, 7):
+    print("ERROR: this package requires Python 3.7 or later!")
     sys.exit(1)
 
 with open("README.md", "r") as fh:


### PR DESCRIPTION
After your issue response, I came to bump the version to 3.7 in setup.py assuming you had forgotten too previously, but you had already done it, but you missed this bit.

I'm not sure you need the check at the top actually as you have >=3.7 in python_requires during the setuyptools.setup() call.

Keep up the good work on the library.