### PR TITLE
fix mongoengine on mongitaclientdisk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,17 @@ build:
 	rm -rf dist
 	python3 setup.py sdist
 
+# Coverage has to be run in this weird way. Why? mongoengine and internal python
+# weirdness. Mongoengine relies on the value of pymongo.MongoClient to be set
+# to either pymongo native or mongoengine BEFORE it gets imported. After import,
+# mongoengine can't be deleted or reloaded or anything afterwards. So it needs to be
+# run in different coverage runs. Then, the --concurrency flag needs to be set to
+# have the coverage actually recorded before coverage combine.
+# For the record, this is horrid.
 test:
-	coverage run --concurrency=multiprocessing -m pytest tests -vx || exit 1
+	coverage run --concurrency=multiprocessing -m pytest tests/test_mongita.py -vx || exit 1
+	coverage run --concurrency=multiprocessing --append -m pytest tests/test_mongoengine.py -vx || exit 1
+	coverage run --concurrency=multiprocessing --append -m pytest tests/test_mongoengine_disk.py -vx || exit 1
 	coverage combine
 	coverage report --include="mongita/*.py,mongitasync"
 	coverage html --include="mongita/*.py,mongitasync"

--- a/mongita/mongita_client.py
+++ b/mongita/mongita_client.py
@@ -145,6 +145,9 @@ class MongitaClientDisk(MongitaClient):
     """
     def __init__(self, host=DEFAULT_STORAGE_DIR, **kwargs):
         host = host or DEFAULT_STORAGE_DIR
+        if isinstance(host, list):
+            # fix for mongoengine passing a list to us
+            host = host[0]
         self.engine = disk_engine.DiskEngine.create(host)
         self.is_primary = True
         super().__init__()

--- a/tests/test_mongita.py
+++ b/tests/test_mongita.py
@@ -6,6 +6,7 @@ import os
 import random
 import sys
 import shutil
+import tempfile
 from concurrent.futures import ThreadPoolExecutor
 
 import bson
@@ -111,7 +112,7 @@ TEST_DOCS = [
     },
 ]
 
-TEST_DIR = '/tmp/mongita_unittests'
+TEST_DIR = os.path.join(tempfile.gettempdir(), 'mongita_unittests')
 _MongitaClientDisk = functools.partial(MongitaClientDisk, TEST_DIR)
 LEN_TEST_DOCS = len(TEST_DOCS)
 CLIENTS = (MongitaClientMemory, _MongitaClientDisk)

--- a/tests/test_mongoengine_disk.py
+++ b/tests/test_mongoengine_disk.py
@@ -5,13 +5,14 @@ import pymongo
 
 sys.path.append(os.getcwd().split('/tests')[0])
 
-from test_mongita import remove_test_dir, _MongitaClientDisk
+import mongita
+from test_mongita import remove_test_dir, TEST_DIR
 
 _OriginalMongoClient = pymongo.MongoClient
 
 
 def setup_function():
-    pymongo.MongoClient = _MongitaClientDisk
+    pymongo.MongoClient = mongita.MongitaClientDisk
     remove_test_dir()
 
 
@@ -44,7 +45,7 @@ def test_mongoengine():
         def __repr__(self):
             return f"POST: {self.title} by {self.author} tagged {self.tags}"
 
-    mongoengine.connect("test")
+    mongoengine.connect("test", host=TEST_DIR)
 
     post1 = Post(title='Fun with MongoEngine')
     post1.content = 'Took a look at MongoEngine today, looks pretty cool.'
@@ -65,4 +66,3 @@ def test_mongoengine():
     assert posts[0].title == 'Fun with MongoEngine'
 
     mongoengine.disconnect()
-


### PR DESCRIPTION
Partially addresses https://github.com/scottrogowski/mongita/issues/23

Mongoengine wasn't working for MongitaClientDisk because it passes forward a list for `host` while MongitaClientDisk was only expecting a string. This wasn't getting caught by unit tests because of a weird interaction in imports. This resolves both the bug and the unit tests.