### PR TITLE
Use ID provided from filter in an upserted document, even if it does not yet exist

### DIFF
--- a/mongita/collection.py
+++ b/mongita/collection.py
@@ -792,7 +792,7 @@ class Collection():
         replacement = copy.deepcopy(replacement)
 
         with self._engine.lock:
-            doc_id = self.__find_one_id(filter)
+            doc_id = self.__find_one_id(filter, upsert=upsert)
             if not doc_id:
                 if upsert:
                     metadata = self.__get_metadata()
@@ -807,7 +807,7 @@ class Collection():
             self.__update_indicies([replacement], metadata)
             return UpdateResult(1, 1)
 
-    def __find_one_id(self, filter, sort=None, skip=None):
+    def __find_one_id(self, filter, sort=None, skip=None, upsert=False):
         """
         Given the filter, return a single object_id or None.
 
@@ -821,7 +821,7 @@ class Collection():
             return self._engine.find_one_id(self._base_location)
 
         if '_id' in filter:
-            if self._engine.doc_exists(self.full_name, filter['_id']):
+            if upsert or self._engine.doc_exists(self.full_name, filter['_id']):
                 return filter['_id']
             return None
 

--- a/tests/test_mongita.py
+++ b/tests/test_mongita.py
@@ -550,6 +550,10 @@ def test_replace_one(client_class):
                               fake_mongoose,
                               upsert=True)
 
+    # upsert a non-existent document, with a provided ID
+    coll.replace_one({'_id': 'id_from_filter'}, {'key': 'value'}, upsert=True)
+    assert coll.count_documents({'_id': 'id_from_filter'}) == 1
+
     # fail gracefully
     assert not coll.find_one({'name': 'not exists'})
     ur = coll.replace_one({'name': 'not exists'}, {'kingdom': 'fake kingdom'})


### PR DESCRIPTION
This fixes #34 by making behavior for `replace_one({'_id': ...}, {...}, upsert=True)` consistent with pymongo.