### PR TITLE
fix: allow usage of pymongo 4 alongside pymongo 3

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,5 @@
 # Mongita requirements
-pymongo>=3.11,<4.0
+pymongo>=3.11,<5.0
 sortedcontainers>=2.3,<3.0
 
 # Testing

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setuptools.setup(
     ],
     python_requires='>=3.7',
     install_requires=[
-        'pymongo>=3.0,<4.0',
+        'pymongo>=3.0,<5.0',
         'sortedcontainers>=2.3,<3.0'
     ],
 )


### PR DESCRIPTION
As stated in issue #43 , it seems pretty easy to allow upgrade of pymongo up to version 4+

This is required in some project that depends on motor (this is my case) that will not work on python 3.11 unless you use motor 3.1.1 (that is bound to pymongo 4).