### PR TITLE
Many enhancements in relation with Beanita and Beanie

### DIFF
--- a/mongita/collection.py
+++ b/mongita/collection.py
@@ -77,8 +77,6 @@ def _validate_update(update):
     :param update dict:
     :rtype: None
     """
-    # TODO: prevent change of _id immutable field and throw something similar to mongo error 66
-    # Performing an update on the path '_id' would modify the immutable field '_id'
 
     if not isinstance(update, dict):
         raise MongitaError("The update parameter must be a dict, not %r" % type(update))
@@ -96,10 +94,8 @@ def _validate_update(update):
         if not isinstance(update_dict, dict):
             raise MongitaError("If present, the update operator must be a dict, "
                                "not %r" % type(update_dict))
-        _id = update_dict.get('_id')
-        if _id:
-            if not isinstance(_id, (str, bson.ObjectId)):
-                raise MongitaError("The update _id must be a bson ObjectId or a string")
+        if update_dict.get('_id'):
+            raise MongitaError("Performing an update on the path '_id' would modify the immutable field '_id'")
 
 
 def _validate_doc(doc):

--- a/mongita/collection.py
+++ b/mongita/collection.py
@@ -634,7 +634,7 @@ def _apply_indx_ops(indx_ops):
 
 class Collection():
     UNIMPLEMENTED = ['aggregate', 'aggregate_raw_batches', 'bulk_write', 'codec_options',
-                     'drop', 'ensure_index',
+                     'ensure_index',
                      'estimated_document_count', 'find_one_and_delete',
                      'find_one_and_replace', 'find_one_and_update', 'find_raw_batches',
                      'inline_map_reduce', 'list_indexes', 'map_reduce', 'next',
@@ -1296,3 +1296,6 @@ class Collection():
         for idx in [idx["_id"] for idx in metadata.get('indexes', {}).values()]:
             self.drop_index(idx)
 
+    @support_alert
+    def drop(self):
+        self.database.drop_collection(self.name)

--- a/mongita/database.py
+++ b/mongita/database.py
@@ -1,4 +1,7 @@
+from typing import Union, MutableMapping, Any
+
 import bson
+from bson import SON
 
 from .collection import Collection
 from .command_cursor import CommandCursor
@@ -108,3 +111,23 @@ class Database():
             del self._cache[collection]
         except KeyError:
             pass
+
+    @support_alert
+    def command(self, command: Union[str, MutableMapping[str, Any]], value: Any = 1):
+        if isinstance(command, str):
+            command = SON({command: value})
+        else:
+            command = SON(command)
+
+        command, value = command.popitem()
+
+        if command == "buildinfo":
+            return {
+                'version': "4.0.0",
+                'versionArray': [4, 0, 0, 0],
+                'debug': False,
+                'modules': [],
+            }
+
+        raise MongitaNotImplementedError("Mongita does not support %s command yet", command)
+

--- a/mongita/results.py
+++ b/mongita/results.py
@@ -1,24 +1,17 @@
-class InsertOneResult():
-    def __init__(self, inserted_id):
-        self.acknowledged = True
-        self.inserted_id = inserted_id
+import pymongo.results
 
 
-class InsertManyResult():
-    def __init__(self, documents):
-        self.acknowledged = True
-        self.inserted_ids = [d['_id'] for d in documents]
+class InsertOneResult(pymongo.results.InsertOneResult):
+    ...
 
 
-class UpdateResult():
-    def __init__(self, matched_count, modified_count, upserted_id=None):
-        self.acknowledged = True
-        self.matched_count = matched_count
-        self.modified_count = modified_count
-        self.upserted_id = upserted_id
+class InsertManyResult(pymongo.results.InsertManyResult):
+    ...
 
 
-class DeleteResult():
-    def __init__(self, deleted_count):
-        self.acknowledged = True
-        self.deleted_count = deleted_count
+class UpdateResult(pymongo.results.UpdateResult):
+    ...
+
+
+class DeleteResult(pymongo.results.DeleteResult):
+    ...

--- a/tests/test_mongita.py
+++ b/tests/test_mongita.py
@@ -1223,6 +1223,11 @@ def test_drop_and_add(client_class):
     assert coll.count_documents({}) == 0
     client.db.snake_hunter.insert_one({'hello': 'world'})
     assert coll.count_documents({}) == 1
+    coll.drop()
+    assert coll.count_documents({}) == 0
+    client.db.snake_hunter.insert_one({'hello': 'world'})
+    assert coll.count_documents({}) == 1
+
 
 
 @pytest.mark.parametrize("client_class", CLIENTS)

--- a/tests/test_mongita.py
+++ b/tests/test_mongita.py
@@ -12,6 +12,7 @@ from concurrent.futures import ThreadPoolExecutor
 import bson
 import pymongo
 import pytest
+from bson import ObjectId
 from pymongo import IndexModel
 
 sys.path.append(os.getcwd().split('/tests')[0])
@@ -1876,6 +1877,27 @@ def test_with_options(client_class):
 
     with pytest.raises(errors.MongitaNotImplementedError):
         coll.with_options(codec_options="TEST")
+
+
+@pytest.mark.parametrize("client_class", CLIENTS)
+def test_commands(client_class):
+    client = client_class()
+    results = client.db.command("buildinfo")
+    assert isinstance(results, dict)
+    assert "version" in results
+    assert results["version"] == "4.0.0"
+    assert results["versionArray"] == [4, 0, 0, 0]
+
+    results = client.db.command({"buildinfo": 1})
+    assert isinstance(results, dict)
+    assert "version" in results
+    assert results["version"] == "4.0.0"
+    assert results["versionArray"] == [4, 0, 0, 0]
+
+    with pytest.raises(errors.MongitaNotImplementedError):
+        client.db.command("collstats", "snake_hunter")
+    with pytest.raises(errors.MongitaNotImplementedError):
+        client.db.command({"filemd5": ObjectId(), "root": "my-root"})
 
 
 def test_close_memory():


### PR DESCRIPTION
[Beanie](https://beanie-odm.dev/) is a Pydantic extension that supports asynchronous database operation through `Motor`. Its author, Roman Right also created a `Mongita` subpackage named [Beanita](https://github.com/roman-right/beanita) that enables async operations in `Mongita` in order to simulate `Motor`’s behaviour. Roman also applied some extension to `Mongita` in `Beanita`.

Beanie also started to use `find_one_and_update` / `find_one_and_replace` and such a support is required in Mongita.  As a Beanita user, I’d like to port as many things into Mongita so that everybody can benefit from Roman features.

In this PR, you will find the following changes:

* Increased usage on `bson.SON` ordered dicts, and `pymongo.results` class
* collection support for:
  * `Collection.create_index` now accepts `name` parameter, and uses `bson.SON` internally.
  * `Collection.create_indexes`, that uses a loop over the already implemented `Collection.create_index`
  * `Collection.drop_indexes`, that uses a loop over the already implemented `Collection.drop_index`
  * `Collection.drop`, that is an alias for `Database.drop_collection`
  * `Collection.find_one_and_update` (with no support for upsert)
  * `Collection.find_one_and_replace`
  * `Collection.find_one_and_delete`
* database support for:
  * `Database.command`, only for `buildinfo` item
* Classes `DeleteResult`, `UpdateResult` supports `raw_result` property (used for the `updatedExisting` value)
  * `InsertOneResult`, `InsertManyResult`, `DeleteResult`, `UpdateResult` are straight subclasses of `pymongo` classes since I reintroduced the `raw_result` property support. I’ve hesitated to remove the classes that are now useless but in order to maintain backward compatibility I preferred to maintain them this way.
  * This implies that all results class are now instanced using a raw_result format returned by a mongo 6.0.5 server
* updating `_id` field will trigger a `MongitaError` similarly to Mongo/PyMongo behavior where the error code 66 is raised if you try to run this: `db.test.insertOne({foo: "bar"}); db.test.updateOne({foo: "bar"}, {$set: {_id: ObjectId()}})`. This behaviour was required by the `Collection.find_one_and_update` method to assert that `_id` is not part of the update. 
  * This implies a change of behavior of Mongita that was relaxed on this and was not emulating mongo properly.